### PR TITLE
 HUB-99 Add InitWithOutput

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -1,6 +1,7 @@
 package logstash
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -49,12 +50,29 @@ func Init(logLevel string, logFileName string, env string, service string, maxSi
 	return true
 }
 
+// InitWithOutput sets up logging with a given output
+// This function should only be called once when the service is started
+func InitWithOutput(logLevel, env, service string, output io.Writer) error {
+	level, ok := LogLevels[logLevel]
+	if !ok {
+		return fmt.Errorf("Unsupported log level: %s", logLevel)
+	}
+
+	log.SetFormatter(&LogstashJsonFormatter{
+		Env:     env,
+		Service: service,
+	})
+
+	log.SetLevel(level)
+	log.SetOutput(output)
+	return nil
+}
+
 func setLogFile(writer io.Writer) {
 	log.SetOutput(writer)
 }
 
-
-func rotationTicker(logFileName string){
+func rotationTicker(logFileName string) {
 
 }
 

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -1,6 +1,7 @@
 package logstash
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -61,6 +62,32 @@ func (s *LogstashTestSuite) TestFileLogger(c *C) {
 	c.Assert(logMessage.Message, Equals, "This is an error message")
 	c.Assert(logMessage.LineNo, Matches, ".*logstash_test.go.*")
 	c.Assert(logMessage.Logger, Matches, ".*TestFileLogger")
+}
+
+func (s *LogstashTestSuite) TestOutputLogger(c *C) {
+
+	b := bytes.NewBuffer(nil)
+
+	InitWithOutput(
+		"INFO",
+		"local",
+		"logstash",
+		b,
+	)
+
+	log.WithFields(log.Fields{"my_field": fmt.Sprintf("%d", 1)}).Error("This is an error message")
+
+	var logMessage LogMessage
+
+	if err := json.Unmarshal(b.Bytes(), &logMessage); err != nil {
+		c.Fail()
+	}
+
+	c.Assert(logMessage.MyField, Equals, "1")
+	c.Assert(logMessage.Level, Equals, "error")
+	c.Assert(logMessage.Message, Equals, "This is an error message")
+	c.Assert(logMessage.LineNo, Matches, ".*logstash_test.go.*")
+	c.Assert(logMessage.Logger, Matches, ".*TestOutputLogger")
 }
 
 func (s *LogstashTestSuite) TestFileRotation(c *C) {


### PR DESCRIPTION
## What

Add need function to init logstash in another way.

```go
func InitWithOutput(logLevel, env, service string, output io.Writer) error {...}
```

## Why

We want to set log output into stdout instead of a file in Kubernetes environment, so add the function.

## How to test

Run the standard test.